### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Coding Standart
 on: [push]
+permissions:
+  contents: read
 jobs:
     # Check there is no syntax errors in the project
     php-linter:


### PR DESCRIPTION
Potential fix for [https://github.com/YounitedCredit/younitedpay-sdk-php/security/code-scanning/3](https://github.com/YounitedCredit/younitedpay-sdk-php/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/main.yml`, directly under `on:` (or under `name:`/`on:` before `jobs:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal least-privilege setting is:

- `contents: read`

This preserves existing functionality (checkout and read-only CI tasks) while preventing accidental broader token access if repo/org defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
